### PR TITLE
Add multiprocessing to quieten tests

### DIFF
--- a/tests/performanceplatform/test_client.py
+++ b/tests/performanceplatform/test_client.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import mock
+import multiprocessing
 from nose.tools import eq_, assert_raises
 from nose import SkipTest
 from requests import Response, HTTPError


### PR DESCRIPTION
Before we were getting

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
    info('process shutting down')
TypeError: 'NoneType' object is not callable
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
    info('process shutting down')
TypeError: 'NoneType' object is not callable
```

:rage1: Adding the multiprocessing module shuts this warning up. :rage4: 
