### PR TITLE
Explicitly install coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
 script: ./run_tests.sh
 after_success:
-  coveralls
+  - pip install coveralls
+  - coveralls
 notifications:
   email: false


### PR DESCRIPTION
The cli tool is needed which doesn't seem to get installed when relying
on setuptools test dependencies.
