### PR TITLE
Set a custom user agent string

### DIFF
--- a/performanceplatform/client/admin.py
+++ b/performanceplatform/client/admin.py
@@ -3,7 +3,7 @@ import requests
 import urllib
 
 import backoff
-
+import pkg_resources
 
 log = logging.getLogger(__name__)
 
@@ -40,13 +40,18 @@ class AdminAPI(object):
         return self._get(
             '/users/{0}'.format(url_quote(email)))
 
+    def get_version(self):
+        return pkg_resources.\
+            get_distribution('performanceplatform-client').version
+
     def _get(self, path):
         json = None
         url = '{0}{1}'.format(self.url, path)
         headers = {
             'Authorization': 'Bearer {0}'.format(self.token),
             'Accept': 'application/json',
-            'User-Agent': 'Performance Platform Client',
+            'User-Agent': 'Performance Platform Client {}'.format(
+                self.get_version())
         }
 
         if self.dry_run:

--- a/tests/performanceplatform/client/test_admin.py
+++ b/tests/performanceplatform/client/test_admin.py
@@ -4,7 +4,7 @@ import multiprocessing
 
 from nose.tools import eq_
 from requests import Response
-from hamcrest import has_entries, match_equality
+from hamcrest import has_entries, match_equality, starts_with
 
 from performanceplatform.client.admin import AdminAPI
 
@@ -22,7 +22,7 @@ class TestAdminAPI(object):
             headers=match_equality(has_entries({
                 'Accept': 'application/json',
                 'Authorization': 'Bearer token',
-                'User-Agent': 'Performance Platform Client',
+                'User-Agent': starts_with('Performance Platform Client'),
             }))
         )
 


### PR DESCRIPTION
This makes it easier to spot requests from the client. It would be nice
to extend this with the ability for the user of this client to set their
own extension to this user agent.
