### PR TITLE
Add support for signon reauth notification

### DIFF
--- a/performanceplatform/client/__init__.py
+++ b/performanceplatform/client/__init__.py
@@ -1,4 +1,4 @@
-__import__('pkg_resources').declare_namespace(__name__)
-
 from .data_set import DataSet
 from .admin import AdminAPI
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/performanceplatform/client/admin.py
+++ b/performanceplatform/client/admin.py
@@ -86,3 +86,6 @@ class AdminAPI(BaseClient):
 
     def add_module_type(self, data):
         return self._post('/module-type', json.dumps(data))
+
+    def reauth(self, uid):
+        return self._post('/auth/gds/api/users/{}/reauth'.format(uid), None)

--- a/tests/performanceplatform/client/test_admin.py
+++ b/tests/performanceplatform/client/test_admin.py
@@ -242,3 +242,20 @@ class TestAdminAPI(object):
         unzipped_bytes = mock_request.call_args[1]['data']
 
         eq_(3000, len(unzipped_bytes))
+
+    @mock.patch('requests.request')
+    def test_reauth(
+            self, mock_request):
+        mock_request.__name__ = 'request'
+
+        client = AdminAPI('http://meta.api.com', 'token')
+        client.reauth('foo')
+
+        mock_request.assert_called_with(
+            'POST',
+            'http://meta.api.com/auth/gds/api/users/foo/reauth',
+            headers=match_equality(has_entries({
+                'Authorization': 'Bearer token',
+            })),
+            data=None
+        )


### PR DESCRIPTION
PerformancePlatform Admin needs to call this explicitly, since we have
duplicate state at the moment. This is hopefully a temporary measure.

See alphagov/performanceplatform-admin#86