### PR TITLE
Handle empty body from endpoints

### DIFF
--- a/performanceplatform/client/base.py
+++ b/performanceplatform/client/base.py
@@ -116,7 +116,8 @@ class BaseClient(object):
                 log.error('[PP-C] {}'.format(response.text))
                 raise
 
-            json = response.json()
+            if response.status_code != 204:
+                json = response.json()
 
         return json
 

--- a/tests/performanceplatform/client/test_admin.py
+++ b/tests/performanceplatform/client/test_admin.py
@@ -262,6 +262,10 @@ class TestAdminAPI(object):
     @mock.patch('requests.request')
     def test_reauth(
             self, mock_request):
+        response = Response()
+        response.status_code = 204
+        response._content = None
+        mock_request.return_value = response
         mock_request.__name__ = 'request'
 
         client = AdminAPI('http://meta.api.com', 'token')


### PR DESCRIPTION
Stagecraft reauth endpoint returns an empty body, which is standard
for apps in the signonotron ecosystem implementing the reauth callback.

This change gracefully handles that.