### PR TITLE
Specify a minimum version of mock

### DIFF
--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage==3.7.1
 coveralls
-mock
+mock>=1.0.1
 nose
 pep8
 PyHamcrest

--- a/tests/performanceplatform/client/test_base.py
+++ b/tests/performanceplatform/client/test_base.py
@@ -90,9 +90,10 @@ class TestBaseClient(object):
         client._post('/foo', [1, 2, 3], chunk_size=2)
 
         eq_(mock_request.call_count, 2)
-        mock_request.assert_has_call(
-            mock.call(mock.ANY, mock.ANY, headers=mock.ANY, data='[1,2]'),
-            mock.call(mock.ANY, mock.ANY, headers=mock.ANY, data='[3]'))
+        mock_request.assert_has_calls(
+            [mock.call(mock.ANY, mock.ANY, headers=mock.ANY, data='[1, 2]'),
+             mock.call(mock.ANY, mock.ANY, headers=mock.ANY, data='[3]')],
+            any_order=True)
 
     @mock.patch('requests.request')
     def test_post_not_chunked_by_default(self, mock_request):


### PR DESCRIPTION
Later mock versions are not compatible with the version of setuptools
on the stack.

Downgrading the version of mock to a compatible one while we investigate
updating setuptools across the board.